### PR TITLE
[Evan Barden] DataMade Code Challenge

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,15 +1,19 @@
+"use strict"
 module.exports = {
   globals: {
     __PATH_PREFIX__: true,
   },
+  parserOptions: {
+    ecmaVersion: 8,
+  },
   rules: {
-    "indent": ["error", 2],
+    indent: ["error", 2],
     "no-console": "off",
-    "strict": ["error", "global"],
-    "curly": "warn",
-    "semi": ["error", "never"],
+    strict: ["error", "global"],
+    curly: "warn",
+    semi: ["error", "never"],
     "space-in-parens": ["error", "never"],
     "space-before-function-paren": ["error", "always"],
-    "space-before-blocks": ["error", "always"]
-  }
+    "space-before-blocks": ["error", "always"],
+  },
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 #
 # Read more on Dockerfile best practices at the source:
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices
-RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client nodejs
+# EB - added this npm install as it was not being installed in the container
+# which was causing npm install to fail
+RUN apt-get update && apt-get install -y --no-install-recommends postgresql-client nodejs npm
 
 # Inside the container, create an app directory and switch into it
 RUN mkdir /app

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,99 @@
-/* TODO: Flesh this out to connect the form to the API and render results
-   in the #address-results div. */
+"use strict"
+/* method that displays an error beneath the form when an input is invalid*/
+function inputError (message) {
+  // create p element for error text
+  const errorText = document.createElement("p")
+  // get the form element from the DOM
+  const addressForm = document.querySelector(".form")
+  // set the text of the p element
+  addressForm.appendChild(errorText).innerHTML = message
+  // add an id to the p element so we can identify it later
+  errorText.setAttribute("id", "input-alert")
+}
+
+/* method that constructs a tr elemenet for insertion into tbody */
+function rowBuilder (part, tag, tbody) {
+  // create tr element
+  const tr = document.createElement("tr")
+  // add a class to the row so we can identify all similar rows later
+  tr.setAttribute("class", "body-row")
+  // create td elements for each piece of data in the row
+  const tdAddress = document.createElement("td")
+  const tdTag = document.createElement("td")
+  // set the text for each of the created td elements
+  tr.appendChild(tdAddress).innerHTML = part
+  tr.appendChild(tdTag).innerHTML = tag
+  // append the row within the specified tbody element
+  tbody.appendChild(tr)
+}
+
+/* method responsible for parsing the address in the input and displaying
+appropriate elements on the page */
+async function parseAddress () {
+  /* FIRST, clean up any previous outputs, if they exist*/
+  // remove the "input-alert" if it exists
+  const apiAlert = document.getElementById("input-alert")
+  if (!!apiAlert) {
+    apiAlert.remove()
+  }
+  // reset display of "address-results" to "none"
+  const resultsTable = document.getElementById("address-results")
+  if (resultsTable.style.display === "block") {
+    resultsTable.style.display = "none"
+  }
+  // reset "parse-type" text to ""
+  const parseType = document.getElementById("parse-type")
+  if (parseType.innerHTML.length) {
+    parseType.innerHTML = ""
+  }
+  // remove all "body-row" elements within tbody
+  const allBodyRows = document.querySelectorAll(".body-row")
+  if (allBodyRows.length) {
+    allBodyRows.forEach((row) => row.remove())
+  }
+
+  /*SECOND, let's parse the address */
+  // get address from input field "address"
+  const address = document.getElementById("address").value
+
+  // if no address, display error to user
+  if (!address) {
+    inputError("Enter an address")
+    return
+  }
+
+  // attempt to parse the address via api
+  try {
+    const response = await fetch(
+      `/api/parse/?input_string=${encodeURIComponent(address)}`
+    )
+
+    // if response is not successful, display error to user and throw Error
+    if (!response.ok) {
+      inputError("API error, please modify address and try again.")
+      throw new Error(`API Error: ${response.status} ${response.statusText}`)
+    }
+
+    // convert response to json and extract desired data
+    const { address_components, address_type } = await response.json()
+
+    // add the address_type text to "parse-type" element
+    parseType.innerHTML = address_type
+
+    // create array from address_components
+    const addreessComponentArray = Object.entries(address_components)
+    // get the desired tbody element
+    const tbody = document.getElementById("address-results-body")
+
+    // iterate through address components and add tr rows to tbody
+    addreessComponentArray.forEach((row) => {
+      rowBuilder(row[1], row[0], tbody)
+    })
+
+    // set the display of of "address-results" to "block" so it is visible
+    resultsTable.style.display = "block"
+  } catch (error) {
+    // if this fails, log the error
+    console.error("Error:", error)
+  }
+}

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -10,10 +10,14 @@
       <h3 id="usaddress-parser"><i class="fa fa-fw fa-map-marker-alt"></i> U.S. address parser</h3>
       <p>Dealing with some messy or unstructured addresses? We can parse them for you.</p>
       <div class="card card-body bg-light">
-        <p><strong>Try it out!</strong> Parse an address in the United States into fields like <code>AddressNumber</code>, <code>StreetName</code> and <code>ZipCode</code>.</p>
-        <form class="form" role="form">
+        <p><strong>Try it out!</strong> Parse an address in the United States into fields like
+          <code>AddressNumber</code>, <code>StreetName</code> and <code>ZipCode</code>.
+        </p>
+        <!-- add an onSubmit to the form (defined in js index.file); return false to resolve async -->
+        <form class="form" role="form" onsubmit="parseAddress(); return false;">
           {% csrf_token %}
-          <input name="address" type="text" class="form-control" id="address" placeholder="123 Main St. Suite 100 Chicago, IL">
+          <input name="address" type="text" class="form-control" id="address"
+            placeholder="123 Main St. Suite 100 Chicago, IL">
           <button id="submit" type="submit" class="btn btn-success mt-3">Parse!</button>
         </form>
       </div>
@@ -28,7 +32,8 @@
               <th>Tag</th>
             </tr>
           </thead>
-          <tbody>
+          <!-- add an id to tbody so we can target it in our js script -->
+          <tbody id="address-results-body">
           </tbody>
         </table>
       </div>
@@ -38,5 +43,5 @@
 {% endblock %}
 
 {% block extra_js %}
-  <script src="{% static 'js/index.js' %}"></script>
+<script src="{% static 'js/index.js' %}"></script>
 {% endblock %}

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -14,11 +14,26 @@ class AddressParse(APIView):
     renderer_classes = [JSONRenderer]
 
     def get(self, request):
-        # TODO: Flesh out this method to parse an address string using the
-        # parse() method and return the parsed components to the frontend.
-        return Response({})
+        # extract the input_string from the request
+        input_string = request.query_params.get('input_string')
+        # if there is no input_string, raise an error
+        if not input_string:
+            raise ParseError("No input provided.")
+        # attempt to parse the input_string
+        address_components, address_type = self.parse(input_string)
+        # return the desired response
+        return Response({
+            'input_string': input_string,
+            'address_components': address_components,
+            'address_type': address_type
+            })
 
     def parse(self, address):
-        # TODO: Implement this method to return the parsed components of a
-        # given address using usaddress: https://github.com/datamade/usaddress
+        # use usaddress to parse with address
+        try:
+            address_components, address_type = usaddress.tag(address)
+            # if unable to, raise an error
+        except usaddress.RepeatedLabelError as e:
+            raise ParseError(f"Error parsing address: {str(e)}")
+        # return the parsed items
         return address_components, address_type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,8 @@
 # Define test fixtures here.
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def client():
+    return APIClient()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,14 +2,37 @@ import pytest
 
 
 def test_api_parse_succeeds(client):
-    # TODO: Finish this test. Send a request to the API and confirm that the
-    # data comes back in the appropriate format.
+
     address_string = '123 main st chicago il'
-    pytest.fail()
+
+    # make an api call with the given address_string
+    response = client.get('/api/parse/', {'input_string': address_string})
+
+    # test response for appropriate status code, data keys, and types of data
+    # returned in those keys
+    try:
+        assert response.status_code == 200
+        assert 'input_string' in response.data
+        assert 'address_components' in response.data
+        assert 'address_type' in response.data
+        assert isinstance(response.data['input_string'], str)
+        assert isinstance(response.data['address_components'], dict)
+        assert isinstance(response.data['address_type'], str)
+    except AssertionError as e:
+        pytest.fail(f"Test failed: {e}")
 
 
 def test_api_parse_raises_error(client):
-    # TODO: Finish this test. The address_string below will raise a
-    # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
+
     address_string = '123 main st chicago il 123 main st'
-    pytest.fail()
+    # make an api call with the given address_string
+    response = client.get('/api/parse/', {'input_string': address_string})
+
+    # test response for appropriate (failed) status code, data key, and
+    # error message within detail.
+    try:
+        assert response.status_code == 400  # Bad Request
+        assert 'detail' in response.data
+        assert 'Error parsing address' in response.data['detail']
+    except AssertionError as e:
+        pytest.fail(f"Test failed: {e}")


### PR DESCRIPTION
## Overview

Completed code for the [DataMade Code challenge](https://docs.google.com/document/d/1f-DqDIeUoikZ5lF0cSTCIrpk6OAWf6OogwFPPLDxmCk/edit), which uses an address parser to separate user-inputted addresses into various address parts and display them in a table.

### Notes
Ran into an initial challenge while getting Docker up and running. The "RUN npm install" call in Dockerfile was failing. Took a while to troubleshoot this and ultimately found that npm was not installed. added "npm" apt-get install call earlier in Dockerfile.

Also faced a js linting error that was difficult to resolve. It seems that async functions throw errors in eslint running older ECMA versions. Most every resource said to update the ecmaVersion in the .eslintrc file, which immediately caused more errors as my Prettier config battled with eslint. Ultimately, updating my settings to not reformat on save and also adding "use strict" at the top of my js files cleared all errors.

## Testing Instructions
As per README, to get your environment up and running with this repo:

Development requires a local installation of [Docker](https://docs.docker.com/install/)
and [Docker Compose](https://docs.docker.com/compose/install/). These are the
only two system-level dependencies you should need.

Once you have Docker and Docker Compose installed, build the application containers:

```
docker-compose build
```

Next, run the app:

```
docker-compose up
```

The app will log to the console, and you should be able to visit it at http://localhost:8000.

### To test
Scenario 1:
1) with the app up and running, and nothing entered in the input, click the "Parse!" button
_result >>  user should see a message prompting them to enter an address._

Scenario 2:
1) enter a valid address into the input: `123 main st chicago il`
2) click the "Parse!" button
_result >> user should see "Street Address" appear next to "Address type:" and a table displaying the parsed address parts will display below. additionally, the previous message to the user, asking them to enter an address, will disappear._

Scenario 3:
1) enter an invalid address into the input: `123 main st chicago il 123 main st`
2) click the "Parse!" button
_result >> user will see the "Address type:" display reset to show no text and the table of parsed address parts will disappear. just below the "Parse!" button will appear a message letting the user know there was an error while parsing the address and an error will also be logged to the console._